### PR TITLE
Update installer README setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This repository uses other repositories which are included as git submodules.
 By default `git clone` does not clone submodules recursively.
 Use `--recurse-submodules` to clone the repo with all included submodules, e.g.
 
-```
+```bash
 git clone --recurse-submodules https://github.com/proteinverse/slivka-bio-installer.git
 ```
 
 If you have already cloned the repository without submodules then run
 
-```
+```bash
 git submodule init && git submodule update
 ```
 
@@ -19,13 +19,13 @@ git submodule init && git submodule update
 As a bare minimum, the installer requires Python, click, ruamel.yaml and Slivka.
 You can install these dependencies with the conda package manager:
 
-```
+```bash
 conda create -n slivka-installer -c conda-forge python=3.10 click ruamel.yaml slivka::slivka
 ```
 
 If you prefer the latest beta version of slivka then install slivka from the _beta_ subdirectory
 
-```
+```bash
 conda create -n slivka-installer -c conda-forge python=3.10 click ruamel.yaml slivka/label/beta::slivka
 ```
 
@@ -37,10 +37,10 @@ A running MongoDB server is required by Slivka at runtime to store job state. Sl
 
 Move to the directory where you cloned the installer repository and run:
 
-```
+```bash
 python install_cli.py --conda-exe autodetect <PATH>
 ```
+
 substituting the project destination for _&lt;PATH&gt;_. Use `--docker-exe autodetect` instead, or as well, when using Docker-backed installers.
 The installer will display the list of tools that will be installed and prompt for the installation method for each one of them.
 If the installation fails, you will be prompted to retry, skip the installation of that service, abort and stop the installer or ignore the error and proceed with the installation.
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Cloning the respository
+## Cloning the repository
 
 This repository uses other repositories which are included as git submodules.
 By default `git clone` does not clone submodules recursively.
-Use `--recurse-submodules` clone the repo with all included submodules e.g.
+Use `--recurse-submodules` to clone the repo with all included submodules, e.g.
 
 ```
 git clone --recurse-submodules https://github.com/proteinverse/slivka-bio-installer.git
@@ -14,10 +14,10 @@ If you have already cloned the repository without submodules then run
 git submodule init && git submodule update
 ```
 
-## Prerequisities
+## Prerequisites
 
-As a bare minimum, the installer requires python, click, ruamel.yaml and slivka.
-You can install all the dependencies with conda package manager:
+As a bare minimum, the installer requires Python, click, ruamel.yaml and Slivka.
+You can install these dependencies with the conda package manager:
 
 ```
 conda create -n slivka-installer -c conda-forge python=3.10 click ruamel.yaml slivka::slivka
@@ -29,16 +29,18 @@ If you prefer the latest beta version of slivka then install slivka from the _be
 conda create -n slivka-installer -c conda-forge python=3.10 click ruamel.yaml slivka/label/beta::slivka
 ```
 
-The installer uses _conda_ and _docker_ which need to be available for proper functiononing. 
+The installer can use _conda_ and/or _docker_ backends. At least one of these must be available and passed to the CLI with `--conda-exe` or `--docker-exe`.
+
+A running MongoDB server is required by Slivka at runtime to store job state. Slivka must be able to connect to one when the server, scheduler, and queue are started.
 
 ## Installing tools
 
 Move to the directory where you cloned the installer repository and run:
 
 ```
-python install.py <PATH>
+python install_cli.py --conda-exe autodetect <PATH>
 ```
-subsituting the project destination for _&lt;PATH&gt;_.
+substituting the project destination for _&lt;PATH&gt;_. Use `--docker-exe autodetect` instead, or as well, when using Docker-backed installers.
 The installer will display the list of tools that will be installed and prompt for the installation method for each one of them.
 If the installation fails, you will be prompted to retry, skip the installation of that service, abort and stop the installer or ignore the error and proceed with the installation.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ The installer can use _conda_ and/or _docker_ backends. At least one of these mu
 
 A running MongoDB server is required by Slivka at runtime to store job state. Slivka must be able to connect to one when the server, scheduler, and queue are started.
 
+## Service configuration files
+
+Service definitions live under `services/`, with each tool version keeping its own configuration files:
+
+- `*.service.yaml` describes the Slivka service itself: metadata, parameters, command line arguments, outputs, tests, and execution runners.
+- `*.conda.yaml` describes the conda-backed installation for that service, including files to copy and the conda channels and dependencies required to run it.
+- `*.docker.yaml` describes the Docker-backed installation for that service, including files to copy and the Dockerfile, image name, and tag used to build the runtime image.
+
 ## Installing tools
 
 Move to the directory where you cloned the installer repository and run:

--- a/README.md
+++ b/README.md
@@ -2,18 +2,23 @@
 
 ## Cloning the repository
 
-This repository uses other repositories which are included as git submodules.
-By default `git clone` does not clone submodules recursively.
-Use `--recurse-submodules` to clone the repo with all included submodules, e.g.
+For most selected-service installs, start with a normal clone:
+
+```bash
+git clone https://github.com/proteinverse/slivka-bio-installer.git
+cd slivka-bio-installer
+```
+
+The only current submodule is the ProteinMPNN source tree used by `mpnn_design_residues-1.0.1`. You do not need to initialise submodules unless you intend to install that service. To fetch all submodules, run:
+
+```bash
+git submodule update --init --recursive
+```
+
+Alternatively, clone the repository with all submodules up front:
 
 ```bash
 git clone --recurse-submodules https://github.com/proteinverse/slivka-bio-installer.git
-```
-
-If you have already cloned the repository without submodules then run
-
-```bash
-git submodule init && git submodule update
 ```
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Slivka Bio Installer
+
 ## Cloning the repository
 
 This repository uses other repositories which are included as git submodules.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Slivka Bio Installer
 
+This repository provides an installer for building Slivka projects from curated bioinformatics service definitions. It is intended for setting up custom Slivka-Bio installations where you want to choose which services to install. The installer can use conda-compatible and/or Docker-backed installation methods depending on the services you select.
+
 ## Cloning the repository
 
 For most selected-service installs, start with a normal clone:


### PR DESCRIPTION
Updates the README to reflect the current installer workflow.

Changes include:
- add a short description of the repository's purpose
- document `install_cli.py` instead of the older `install.py` command
- clarify that submodules are optional and currently only needed for the ProteinMPNN service
- document MongoDB as a Slivka runtime dependency
- clarify conda/Docker installer backend requirements
- add guidance on service configuration
- fix minor wording and typo issues